### PR TITLE
Removed color output.

### DIFF
--- a/lib/capistrano-conditional/deploy.rb
+++ b/lib/capistrano-conditional/deploy.rb
@@ -25,7 +25,8 @@ class ConditionalDeploy
 
     # Need to create stub for method in case called from
     @@deploy_context.send(:task, name) do
-      puts msg.cyan unless opts[:silent]
+      msg = msg.cyan if msg.respond_to?(:cyan)
+      puts msg unless opts[:silent]
     end
   end
 


### PR DESCRIPTION
Recent versions of SSHKit are not depending on colorize gem anymore, causing an exception in this line. By just omitting the coloring, all versions should work.
